### PR TITLE
Added application TeslaChargePortOpener

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
 - [rnd-android-wear-tesla](https://github.com/eleks/rnd-android-wear-tesla) - Android Wear
 - [TeslaFTW](https://github.com/ErikDeBruijn/TeslaFTW) - Pebble App
 - [VisibleTesla](https://github.com/jpasqua/VisibleTesla) - Java App
+- [TeslaChargePortOpener](https://github.com/fredilarsen/TeslaChargeDoorOpener) - Arduino sketch for opening the charge door by RF. Easy build.
 
 ## Projects
 


### PR DESCRIPTION
This application can be used on an Arduino with a STX882 transmitter, to do the same as the button on a Tesla charge cable, opening the charge door. This hardware is very low cost and the project is easy to build.

The application is tested and feature complete. It is used with a Tesla Model 3, and the charge port opening replicates the behavior of the Tesla charge cable, meaning it will also work with the rest of the Tesla models.

**By submitting this pull request, I promise I have read the Contribution Guidelines twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**

⬆⬆⬆⬆⬆⬆⬆⬆⬆⬆

# Contribution Guidelines

Ensure your pull request adheres to the following guidelines:

1. **If you just created something, wait at least 30 days before submitting.** This is to give it some time to mature and ensure it's not just a publish-and-forget type of project.
2. The pull request should have a useful title and include a link to the project and why it should be included.

Thank you for your suggestion!
